### PR TITLE
Use File.path instead of static /

### DIFF
--- a/src/main/java/com/testautomationguru/utility/PDFUtil.java
+++ b/src/main/java/com/testautomationguru/utility/PDFUtil.java
@@ -478,7 +478,7 @@ public class PDFUtil {
 				
 				for(int iPage=startPage-1;iPage<endPage;iPage++){
 					String fileName = new File(file1).getName().replace(".pdf", "_") + (iPage + 1);
-					fileName = this.getImageDestinationPath() + "/" + fileName + "_diff.png";
+					fileName = this.getImageDestinationPath() + File.separator + fileName + "_diff.png";
 					
 					logger.info("Comparing Page No : " + (iPage+1));
 					BufferedImage image1 = pdfRenderer1.renderImageWithDPI(iPage, 300, ImageType.RGB);

--- a/src/main/java/com/testautomationguru/utility/PDFUtil.java
+++ b/src/main/java/com/testautomationguru/utility/PDFUtil.java
@@ -585,7 +585,7 @@ public class PDFUtil {
 	private void createImageDestinationDirectory(String file) throws IOException{
 		if(null==this.imageDestinationPath){
 			File sourceFile = new File(file);
-			String destinationDir = sourceFile.getParent() + "/temp/";
+			String destinationDir = sourceFile.getParent() + File.separator + "temp";
 			this.imageDestinationPath=destinationDir;
 			this.createFolder(destinationDir);
 		}


### PR DESCRIPTION
Fix a problem on Windows environment if you use imageCompare and set no imageDestinationDirectory